### PR TITLE
SER-688 Added prefix and ticket update

### DIFF
--- a/kapajira/bin/on_alert.py
+++ b/kapajira/bin/on_alert.py
@@ -15,4 +15,4 @@ alert_data = AlertDataParser.parse(sys.stdin.read())
 if alert_data.level == 'CRITICAL':
     issue = Issue(alert_data.id, alert_data.message, issue_component=issue_component)
     reporter = JiraReporter()
-    reporter.create_issue(issue)
+    reporter.create_or_update_issue(issue)

--- a/kapajira/jira/issues.py
+++ b/kapajira/jira/issues.py
@@ -1,10 +1,11 @@
 import hashlib
-
+from datetime import datetime
 
 class Issue:
     """This class is a simple wrapper for JIRA issue"""
 
     DESCRIPTION_HASH_FORMAT = '\n\n========================\nHash: {hash}'
+    LAST_OCCURRENCE_FORMAT = '\nLast Occurrence: {occurrence} UTC'
 
     def __init__(self, summary, description, issue_type='Defect', issue_component=None):
         """ Set up the jira issue """
@@ -34,13 +35,18 @@ class Issue:
         """ Get issue summary """
         # prevent jira.exceptions.JIRAError:
         # HTTP 400: "The summary is invalid because it contains newline characters."
-        return self._summary.replace("\n", '')
+        return ("Kap Alert: " + self._summary.replace("\n", ''))[:255]
 
     def get_description(self):
         """ Get report detailed description """
         description = self._description.strip()
         description += self.DESCRIPTION_HASH_FORMAT.format(hash=self._issue_hash)
+        description += self.LAST_OCCURRENCE_FORMAT.format(occurrence=datetime.utcnow())
         return description
+
+    def get_labels(self):
+        """ Get a list of labels """
+        return ["KapacitorAlert"]
 
     def get_component(self):
         return self._issue_component

--- a/kapajira/jira/reporter.py
+++ b/kapajira/jira/reporter.py
@@ -17,7 +17,7 @@ class JiraReporter:
         self._jira = JIRA(server=CFG['url'],
                           basic_auth=(CFG['user'], CFG['password']))
 
-    def issue_exists(self, issue_hash: str):
+    def existing_issue(self, issue_hash: str):
         """Checks if JIRA issues with issue_hash in description exists.
 
         Searches for 'Open' JIRA issues which contains issue_hash in their
@@ -39,7 +39,7 @@ class JiraReporter:
             return None
 
 
-    def create_issue(self, issue):
+    def create_or_update_issue(self, issue):
         """Creates an JIRA issue or updates and existing one
 
         Creates JIRA issue at project taken from configuration file.
@@ -49,7 +49,7 @@ class JiraReporter:
 
         """
 
-        existing_issue = self.issue_exists(issue.get_issue_hash())
+        existing_issue = self.existing_issue(issue.get_issue_hash())
 
         issue_dict = {
             'project': self._project,
@@ -62,7 +62,7 @@ class JiraReporter:
         if issue.get_component() is not None and self._component_exists(issue.get_component()):
             issue_dict['components'] = [{'name': issue.get_component()}]
 
-        if existing_issue:
+        if existing_issue is not None:
             existing_issue.update(fields={'description': issue_dict['description']})
         else:
             self._jira.create_issue(fields=issue_dict)

--- a/kapajira/jira/reporter.py
+++ b/kapajira/jira/reporter.py
@@ -33,7 +33,7 @@ class JiraReporter:
         """
         issues = self._search_for_issues(issue_hash, self.STATUS_CLOSED)
 
-        if issues is not None:
+        if issues:
             return issues[0]
         else:
             return None
@@ -62,7 +62,7 @@ class JiraReporter:
         if issue.get_component() is not None and self._component_exists(issue.get_component()):
             issue_dict['components'] = [{'name': issue.get_component()}]
 
-        if existing_issue is not None:
+        if existing_issue:
             existing_issue.update(fields={'description' : issue_dict['description']})
         else:
             self._jira.create_issue(fields=issue_dict)

--- a/kapajira/jira/reporter.py
+++ b/kapajira/jira/reporter.py
@@ -63,7 +63,7 @@ class JiraReporter:
             issue_dict['components'] = [{'name': issue.get_component()}]
 
         if existing_issue:
-            existing_issue.update(fields={'description' : issue_dict['description']})
+            existing_issue.update(fields={'description': issue_dict['description']})
         else:
             self._jira.create_issue(fields=issue_dict)
 

--- a/kapajira/jira/reporter.py
+++ b/kapajira/jira/reporter.py
@@ -33,7 +33,7 @@ class JiraReporter:
         """
         issues = self._search_for_issues(issue_hash, self.STATUS_CLOSED)
 
-        if issues:
+        if issues is not None:
             return issues[0]
         else:
             return None
@@ -62,7 +62,7 @@ class JiraReporter:
         if issue.get_component() is not None and self._component_exists(issue.get_component()):
             issue_dict['components'] = [{'name': issue.get_component()}]
 
-        if existing_issue:
+        if existing_issue is not None:
             existing_issue.update(fields={'description' : issue_dict['description']})
         else:
             self._jira.create_issue(fields=issue_dict)

--- a/kapajira/test/test_jira_reporter.py
+++ b/kapajira/test/test_jira_reporter.py
@@ -22,7 +22,7 @@ class TestJiraReporter(unittest.TestCase):
         jira_mock.search_issues.return_value = ['some_issue']
         jp = JiraReporter()
 
-        self.assertTrue(jp.issue_exists('hash'))
+        self.assertTrue(jp.existing_issue('hash'))
         jira_mock.search_issues.assert_called_once_with(self.JIRA_SEARCH_STRING)
 
     @patch('kapajira.jira.reporter.JIRA')
@@ -31,7 +31,7 @@ class TestJiraReporter(unittest.TestCase):
         jira_mock.search_issues.return_value = []
         jp = JiraReporter()
 
-        self.assertFalse(jp.issue_exists('hash'))
+        self.assertFalse(jp.existing_issue('hash'))
         jira_mock.search_issues.assert_called_once_with(self.JIRA_SEARCH_STRING)
 
     @patch('kapajira.jira.reporter.JIRA')
@@ -51,7 +51,7 @@ class TestJiraReporter(unittest.TestCase):
         issue_mock.get_issue_type.return_value = 'some_issuetype'
         issue_mock.get_labels.return_value = ['some_label']
 
-        jp.create_issue(issue_mock)
+        jp.create_or_update_issue(issue_mock)
         jira_mock.create_issue.assert_called_once_with(fields={
             'project': 'some_project',
             'summary': 'some_summary',
@@ -71,5 +71,5 @@ class TestJiraReporter(unittest.TestCase):
         issue_mock = Mock(spec=Issue)
         issue_mock.get_description.return_value = 'some_desc'
 
-        jp.create_issue(issue_mock)
+        jp.create_or_update_issue(issue_mock)
         jira_issue_mock.update.assert_called_once_with(fields={'description': 'some_desc'})

--- a/kapajira/test/test_jira_reporter.py
+++ b/kapajira/test/test_jira_reporter.py
@@ -37,14 +37,18 @@ class TestJiraReporter(unittest.TestCase):
         issue_mock.get_description.return_value = 'some_desc'
         issue_mock.get_issue_hash.return_value = 'some_hash'
 
-        self.assertIsNotNone(jp.create_issue(issue_mock))
+        jp.create_issue(issue_mock)
 
     @patch('kapajira.jira.reporter.JIRA')
     def test_issue_is_not_created_if_one_exist(self, jira_mock):
+        jira_issue_mock = Mock()
+
         jira_mock = jira_mock.return_value
-        jira_mock.search_issues.return_value = ['some_issue']
+        jira_mock.search_issues.return_value = [jira_issue_mock]
 
         jp = JiraReporter()
         issue_mock = Mock(spec=Issue)
+        issue_mock.get_description.return_value = 'some_desc'
 
-        self.assertIsNone(jp.create_issue(issue_mock))
+        jp.create_issue(issue_mock)
+        jira_issue_mock.update.assert_called_once_with(fields={'description': 'some_desc'})

--- a/kapajira/test/test_jira_reporter.py
+++ b/kapajira/test/test_jira_reporter.py
@@ -31,7 +31,7 @@ class TestJiraReporter(unittest.TestCase):
         jira_mock.search_issues.return_value = []
         jp = JiraReporter()
 
-        self.assertFalse(jp.existing_issue('hash'))
+        self.assertIsNone(jp.existing_issue('hash'))
         jira_mock.search_issues.assert_called_once_with(self.JIRA_SEARCH_STRING)
 
     @patch('kapajira.jira.reporter.JIRA')

--- a/kapajira/test/test_jira_reporter.py
+++ b/kapajira/test/test_jira_reporter.py
@@ -4,6 +4,14 @@ from unittest.mock import patch, Mock
 from kapajira.jira.reporter import JiraReporter
 from kapajira.jira.issues import Issue
 
+config_mock_values = {'project': 'some_project',
+                      'url': 'some_url',
+                      'user': 'some_user',
+                      'password': 'some_password'}
+
+
+def config_mock_getitem(name):
+    return config_mock_values[name]
 
 class TestJiraReporter(unittest.TestCase):
     JIRA_SEARCH_STRING = "description ~ 'hash' AND status != 'Closed'"
@@ -27,17 +35,30 @@ class TestJiraReporter(unittest.TestCase):
         jira_mock.search_issues.assert_called_once_with(self.JIRA_SEARCH_STRING)
 
     @patch('kapajira.jira.reporter.JIRA')
-    def test_issue_is_created_if_one_does_not_exist(self, jira_mock):
+    @patch('kapajira.jira.reporter.CFG')
+    def test_issue_is_created_if_one_does_not_exist(self, config_mock, jira_mock):
         jira_mock = jira_mock.return_value
         jira_mock.search_issues.return_value = []
+
+        config_mock.__getitem__.side_effect = config_mock_getitem
 
         jp = JiraReporter()
 
         issue_mock = Mock(spec=Issue)
         issue_mock.get_description.return_value = 'some_desc'
         issue_mock.get_issue_hash.return_value = 'some_hash'
+        issue_mock.get_summary.return_value = 'some_summary'
+        issue_mock.get_issue_type.return_value = 'some_issuetype'
+        issue_mock.get_labels.return_value = ['some_label']
 
         jp.create_issue(issue_mock)
+        jira_mock.create_issue.assert_called_once_with(fields={
+            'project': 'some_project',
+            'summary': 'some_summary',
+            'description': 'some_desc',
+            'issuetype': 'some_issuetype',
+            'labels': ['some_label']
+        })
 
     @patch('kapajira.jira.reporter.JIRA')
     def test_issue_is_not_created_if_one_exist(self, jira_mock):

--- a/kapajira/test/test_jira_reporter.py
+++ b/kapajira/test/test_jira_reporter.py
@@ -22,7 +22,7 @@ class TestJiraReporter(unittest.TestCase):
         jira_mock.search_issues.return_value = ['some_issue']
         jp = JiraReporter()
 
-        self.assertTrue(jp.existing_issue('hash'))
+        self.assertEqual('some_issue', jp.existing_issue('hash'))
         jira_mock.search_issues.assert_called_once_with(self.JIRA_SEARCH_STRING)
 
     @patch('kapajira.jira.reporter.JIRA')


### PR DESCRIPTION
Contains changes for subtasks
https://wikia-inc.atlassian.net/browse/SER-689
and
https://wikia-inc.atlassian.net/browse/SER-690

All jira tickets are now created with a common prefix in summary (Kap Alert) + there will be labels + if ticket exists we update it with last occurrence information.