### PR TITLE
Ser-779 Changed ticket creation granularity

### DIFF
--- a/kapajira/bin/on_alert.py
+++ b/kapajira/bin/on_alert.py
@@ -10,9 +10,10 @@ from kapajira.kapacitor.utils import AlertDataParser
 
 
 issue_component = sys.argv[1] if len(sys.argv) > 1 else None;
+alert_name = sys.argv[2] if len(sys.argv) > 2 else None;
 
 alert_data = AlertDataParser.parse(sys.stdin.read())
 if alert_data.level == 'CRITICAL':
-    issue = Issue(alert_data.id, alert_data.message, issue_component=issue_component)
+    issue = Issue(alert_data.id, alert_data.message, issue_component=issue_component, alert_name=alert_name)
     reporter = JiraReporter()
     reporter.create_or_update_issue(issue)

--- a/kapajira/jira/issues.py
+++ b/kapajira/jira/issues.py
@@ -7,15 +7,16 @@ class Issue:
     DESCRIPTION_HASH_FORMAT = '\n\n========================\nHash: {hash}'
     LAST_OCCURRENCE_FORMAT = '\nLast Occurrence: {occurrence} UTC'
 
-    def __init__(self, summary, description, issue_type='Defect', issue_component=None):
+    def __init__(self, alert_id, description, issue_type='Defect', issue_component=None, alert_name=None):
         """ Set up the jira issue """
-        self._summary = summary
+        self.alert_id = alert_id
         self._description = description
         self._issue_type = {
             'name': issue_type
         }
         self._issue_component = issue_component
-        self._issue_hash = self._create_hash(summary)
+        self._alert_name = alert_name
+        self._issue_hash = self._create_hash(get_summary())
 
     @staticmethod
     def _create_hash(data_to_hash):
@@ -33,9 +34,15 @@ class Issue:
 
     def get_summary(self):
         """ Get issue summary """
-        # prevent jira.exceptions.JIRAError:
-        # HTTP 400: "The summary is invalid because it contains newline characters."
-        return ("Kap Alert: " + self._summary.replace("\n", ''))[:255]
+        if issue_component and alert_name:
+          summary = self._alert_name + "/" + self._issue_component
+        else:
+          # prevent jira.exceptions.JIRAError:        
+          # HTTP 400: "The summary is invalid because it contains newline characters."
+          summary = self._alert_id.replace("\n", '')
+          
+        #Max length of summary 255 characters
+        return ("Kap Alert: " + summary)[:255]
 
     def get_description(self):
         """ Get report detailed description """

--- a/kapajira/jira/issues.py
+++ b/kapajira/jira/issues.py
@@ -9,14 +9,14 @@ class Issue:
 
     def __init__(self, alert_id, description, issue_type='Defect', issue_component=None, alert_name=None):
         """ Set up the jira issue """
-        self.alert_id = alert_id
+        self._alert_id = alert_id
         self._description = description
         self._issue_type = {
             'name': issue_type
         }
         self._issue_component = issue_component
         self._alert_name = alert_name
-        self._issue_hash = self._create_hash(get_summary())
+        self._issue_hash = self._create_hash(self.get_summary())
 
     @staticmethod
     def _create_hash(data_to_hash):
@@ -34,7 +34,7 @@ class Issue:
 
     def get_summary(self):
         """ Get issue summary """
-        if issue_component and alert_name:
+        if self._issue_component and self._alert_name:
           summary = self._alert_name + "/" + self._issue_component
         else:
           # prevent jira.exceptions.JIRAError:        


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SER-779

Kapajira now creates ticket per alert name + service name pair, not including instance id. This will cause less tickets to be created

Here's the chef change which was needed to pass the additional parameter - alert name: https://github.com/Wikia/chef-repo/pull/12512