### PR TITLE
SER-816 Added support for multiple projects

### DIFF
--- a/kapajira/test/test_jira_reporter.py
+++ b/kapajira/test/test_jira_reporter.py
@@ -1,17 +1,33 @@
 import unittest
 
 from unittest.mock import patch, Mock
+from jira.resources import Component
 from kapajira.jira.reporter import JiraReporter
 from kapajira.jira.issues import Issue
 
-config_mock_values = {'project': 'some_project',
+config_mock_values = {'projects': ['some_project_1', 'some_project_2'],
                       'url': 'some_url',
                       'user': 'some_user',
                       'password': 'some_password'}
 
 
+def mock_component(name):
+    mock = Mock()
+    mock.name = name
+    return mock
+
+project_components_mock_values = {
+    'some_project_1': [mock_component('some_component_1'), mock_component('some_component_2')],
+    'some_project_2': [mock_component('some_component_3'), mock_component('some_component_4')]}
+
+
 def config_mock_getitem(name):
     return config_mock_values[name]
+
+
+def jira_mock_getcomponents(project):
+    return project_components_mock_values[project]
+
 
 class TestJiraReporter(unittest.TestCase):
     JIRA_SEARCH_STRING = "description ~ 'hash' AND status != 'Closed'"
@@ -53,11 +69,40 @@ class TestJiraReporter(unittest.TestCase):
 
         jp.create_or_update_issue(issue_mock)
         jira_mock.create_issue.assert_called_once_with(fields={
-            'project': 'some_project',
+            'project': 'some_project_1',
             'summary': 'some_summary',
             'description': 'some_desc',
             'issuetype': 'some_issuetype',
             'labels': ['some_label']
+        })
+
+    @patch('kapajira.jira.reporter.JIRA')
+    @patch('kapajira.jira.reporter.CFG')
+    def test_issue_is_created_if_one_does_not_exist_second_project(self, config_mock, jira_mock):
+        jira_mock = jira_mock.return_value
+        jira_mock.search_issues.return_value = []
+        jira_mock.project_components.side_effect = jira_mock_getcomponents
+
+        config_mock.__getitem__.side_effect = config_mock_getitem
+
+        jp = JiraReporter()
+
+        issue_mock = Mock(spec=Issue)
+        issue_mock.get_description.return_value = 'some_desc'
+        issue_mock.get_issue_hash.return_value = 'some_hash'
+        issue_mock.get_summary.return_value = 'some_summary'
+        issue_mock.get_issue_type.return_value = 'some_issuetype'
+        issue_mock.get_labels.return_value = ['some_label']
+        issue_mock.get_component.return_value = 'some_component_3'
+
+        jp.create_or_update_issue(issue_mock)
+        jira_mock.create_issue.assert_called_once_with(fields={
+            'project': 'some_project_2',
+            'summary': 'some_summary',
+            'description': 'some_desc',
+            'issuetype': 'some_issuetype',
+            'labels': ['some_label'],
+            'components': [{'name': 'some_component_3'}]
         })
 
     @patch('kapajira.jira.reporter.JIRA')


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SER-816

Changed the project field to a list which enables defining multiple projects as place to file a ticket. Components are used to determine the target location.

Before merging we need to adjust config in chef: https://github.com/Wikia/chef-repo/blob/6e3bffafc60ecc6729c5afce8c39e0cdc4dfdb85/cookbooks/kapajira/templates/default/config.py.erb#L10